### PR TITLE
CORCI-436 ci: Enable fault-injection tests in CI.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -187,46 +187,44 @@ pipeline {
                     }
                 }
             stage('Fault injection') {
-                    agent {
-                        label 'ci_vm1'
-                    }
-		    options {
-                        timeout(time: 60, unit: 'MINUTES')
-                    }
+                agent {
+                    label 'ci_vm1'
+                }
+		options {
+                    timeout(time: 60, unit: 'MINUTES')
+                }
                 steps {
-                    steps {
-                        provisionNodes NODELIST: env.NODELIST,
-                           node_count: 1,
-                           snapshot: true
-                        runTest stashes: [ 'CentOS-install', 'CentOS-build-vars' ],
-                                script: """set -x
-                                    . ./.build_vars-Linux.sh
-                                    CART_BASE=\${SL_PREFIX%/install*}
-                                    NODELIST=$nodelist
-                                    NODE=\${NODELIST%%,*}
-                                    trap 'set +e; set -x; ssh -i ci_key jenkins@\$NODE "set -ex; sudo umount \$CART_BASE"' EXIT
-                                    ssh -i ci_key jenkins@\$NODE "set -x
-                                        set -e
-                                        sudo mkdir -p \$CART_BASE
-                                        sudo mount -t nfs \$HOSTNAME:\$PWD \$CART_BASE
-                                        cd \$CART_BASE
-                                        ./test/iof_test_alloc_fail.py
-                                    """,
-                        publishValgrind (
-                            failBuildOnInvalidReports: true,
-                            failBuildOnMissingReports: false,
-                            failThresholdDefinitelyLost: '0',
-                            failThresholdInvalidReadWrite: '0',
-                            failThresholdTotal: '0',
-                            pattern: '**/*.memcheck',
-                            publishResultsForAbortedBuilds: false,
-                            publishResultsForFailedBuilds: false,
-                            sourceSubstitutionPaths: '',
-                            unstableThresholdDefinitelyLost: '',
-                            unstableThresholdInvalidReadWrite: '',
-                            unstableThresholdTotal: ''
-                        )
-                    }
+                    provisionNodes NODELIST: env.NODELIST,
+                        node_count: 1,
+                        snapshot: true
+                    runTest stashes: [ 'CentOS-install', 'CentOS-build-vars' ],
+                        script: """set -x
+                            . ./.build_vars-Linux.sh
+                            CART_BASE=\${SL_PREFIX%/install*}
+                            NODELIST=$nodelist
+                            NODE=\${NODELIST%%,*}
+                            trap 'set +e; set -x; ssh -i ci_key jenkins@\$NODE "set -ex; sudo umount \$CART_BASE"' EXIT
+                            ssh -i ci_key jenkins@\$NODE "set -x
+                                set -e
+                                sudo mkdir -p \$CART_BASE
+                                sudo mount -t nfs \$HOSTNAME:\$PWD \$CART_BASE
+                                cd \$CART_BASE
+                                ./test/iof_test_alloc_fail.py
+                            """
+                    publishValgrind (
+                        failBuildOnInvalidReports: true,
+                        failBuildOnMissingReports: false,
+                        failThresholdDefinitelyLost: '0',
+                        failThresholdInvalidReadWrite: '0',
+                        failThresholdTotal: '0',
+                        pattern: '**/*.memcheck',
+                        publishResultsForAbortedBuilds: false,
+                        publishResultsForFailedBuilds: false,
+                        sourceSubstitutionPaths: '',
+                        unstableThresholdDefinitelyLost: '',
+                        unstableThresholdInvalidReadWrite: '',
+                        unstableThresholdTotal: ''
+                    )
                     post {
                         always {
                             archiveArtifacts artifacts: '**/*.log,**/*.memcheck'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,7 +197,8 @@ pipeline {
                     }
                 steps {
                         runTest stashes: [ 'CentOS-install', 'CentOS-build-vars' ],
-                                script: """./test/iof_test_alloc_fail.py"""
+                                script: """find .
+                                    ./test/iof_test_alloc_fail.py"""
                         publishValgrind (
                             failBuildOnInvalidReports: true,
                             failBuildOnMissingReports: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,7 +190,7 @@ pipeline {
                 agent {
                     label 'ci_vm1'
                 }
-		options {
+                options {
                     timeout(time: 60, unit: 'MINUTES')
                 }
                 steps {
@@ -209,6 +209,7 @@ pipeline {
                                 sudo mkdir -p \$CART_BASE
                                 sudo mount -t nfs \$HOSTNAME:\$PWD \$CART_BASE
                                 cd \$CART_BASE
+                                pip3.4 install --user tabulate
                                 ./test/iof_test_alloc_fail.py"
                             """
                     publishValgrind (

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -209,6 +209,7 @@ pipeline {
                                 sudo mkdir -p \$CART_BASE
                                 sudo mount -t nfs \$HOSTNAME:\$PWD \$CART_BASE
                                 cd \$CART_BASE
+                                ln -s /usr/bin/fusermount install/Linux/bin/fusermount3
                                 pip3.4 install --user tabulate
                                 ./test/iof_test_alloc_fail.py"
                             """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -209,7 +209,7 @@ pipeline {
                                 sudo mkdir -p \$CART_BASE
                                 sudo mount -t nfs \$HOSTNAME:\$PWD \$CART_BASE
                                 cd \$CART_BASE
-                                ./test/iof_test_alloc_fail.py
+                                ./test/iof_test_alloc_fail.py"
                             """
                     publishValgrind (
                         failBuildOnInvalidReports: true,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -197,21 +197,21 @@ pipeline {
                     }
                 steps {
                         runTest stashes: [ 'CentOS-install', 'CentOS-build-vars' ],
-                                script: """./test/iof_test_alloc_fail.py""",
-                                publishValgrind (
-                                    failBuildOnInvalidReports: true,
-                                    failBuildOnMissingReports: false,
-                                    failThresholdDefinitelyLost: '0',
-                                    failThresholdInvalidReadWrite: '0',
-                                    failThresholdTotal: '0',
-                                    pattern: '**/*.memcheck',
-                                    publishResultsForAbortedBuilds: false,
-                                    publishResultsForFailedBuilds: false,
-                                    sourceSubstitutionPaths: '',
-                                    unstableThresholdDefinitelyLost: '',
-                                    unstableThresholdInvalidReadWrite: '',
-                                    unstableThresholdTotal: ''
-                                )
+                                script: """./test/iof_test_alloc_fail.py"""
+                        publishValgrind (
+                            failBuildOnInvalidReports: true,
+                            failBuildOnMissingReports: false,
+                            failThresholdDefinitelyLost: '0',
+                            failThresholdInvalidReadWrite: '0',
+                            failThresholdTotal: '0',
+                            pattern: '**/*.memcheck',
+                            publishResultsForAbortedBuilds: false,
+                            publishResultsForFailedBuilds: false,
+                            sourceSubstitutionPaths: '',
+                            unstableThresholdDefinitelyLost: '',
+                            unstableThresholdInvalidReadWrite: '',
+                            unstableThresholdTotal: ''
+                        )
                     }
                     post {
                         always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,7 +224,8 @@ pipeline {
                         unstableThresholdDefinitelyLost: '',
                         unstableThresholdInvalidReadWrite: '',
                         unstableThresholdTotal: ''
-                    )
+                        )
+                    }
                     post {
                         always {
                             archiveArtifacts artifacts: '**/*.log,**/*.memcheck'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -198,6 +198,8 @@ pipeline {
                 steps {
                         runTest stashes: [ 'CentOS-install', 'CentOS-build-vars' ],
                                 script: """find .
+                                    pwd
+                                    cat ./.build_vars-Linux.sh
                                     ./test/iof_test_alloc_fail.py"""
                         publishValgrind (
                             failBuildOnInvalidReports: true,

--- a/test/iof_test_alloc_fail.py
+++ b/test/iof_test_alloc_fail.py
@@ -198,7 +198,8 @@ def run_app(ionss=False):
                               dir=export_tmp_dir)
     ctrl_fs_dir = os.path.join(prefix, '.ctrl')
 
-    use_valgrind = os.getenv('TR_USE_VALGRIND', default=None)
+    # Hardcode this to on for now to enable valgrind in CI.
+    use_valgrind = True
 
     if ionss:
         bin_cmd = 'ionss'
@@ -242,11 +243,11 @@ def run_app(ionss=False):
             cmd.append('--suppressions={}'.format(crt_suppressfile))
 
         # If running in a CI environment then output to xml.
-        if use_valgrind == 'memcheck':
+        if use_valgrind:
             cmd.extend(['--xml=yes',
                         '--xml-file={}'.format(
                             os.path.join(log_top_dir, 'af',
-                                         "valgrind-{}.xml".format(floc)))])
+                                         "fail_{}.memcheck".format(floc)))])
         if ionss:
             cmd.append(os.path.join(jdata['PREFIX'], 'bin', 'ionss'))
             cmd.extend(['-c', config_file])


### PR DESCRIPTION
Simply call the iof_test_alloc_fail script.

Change-Id: I3b9e21bcba896b3ee76fa237aa5feb44cb857a32
Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>