### PR TITLE
CART-566 ft: update call to D_SHOULD_FAIL()

### DIFF
--- a/src/ionss/ionss.c
+++ b/src/ionss/ionss.c
@@ -67,6 +67,7 @@
 		IOF_PROTO_SERVER_VER,		\
 		0)
 
+static struct d_fault_attr_t *fault_attr_shutdown;
 static int shutdown;
 static ATOMIC unsigned int cnss_count;
 
@@ -2773,6 +2774,8 @@ int main(int argc, char **argv)
 	crt_group_rank(base.primary_group, &base.my_rank);
 	crt_group_size(base.primary_group, &base.num_ranks);
 
+	fault_attr_shutdown = d_fault_attr_lookup(100);
+
 	base.gs = ios_gah_init(base.my_rank);
 	if (!base.gs) {
 		D_GOTO(shutdown_no_proj, exit_rc = -DER_NOMEM);
@@ -3002,7 +3005,7 @@ int main(int argc, char **argv)
 
 	shutdown = 0;
 
-	if (D_SHOULD_FAIL(100)) {
+	if (D_SHOULD_FAIL(fault_attr_shutdown)) {
 		D_GOTO(shutdown, exit_rc = -DER_SHUTDOWN);
 	}
 


### PR DESCRIPTION
CART-566 changed the fault injection API. Update IOF accordingly. More
specifically, now D_SHOULD_FAIL() takes a pointer to fault attributions
instead of a fault id.

Change-Id: Ifbb8131277979253cec72b2f4a6c8f6c6aab7947