### PR TITLE
CORCI-607 Cancel previous jobs in progress

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,6 +62,12 @@ pipeline {
     }
 
     stages {
+        stage('Cancel Previous Builds') {
+            when { changeRequest() }
+            steps {
+                cancelPreviousBuilds()
+            }
+        }
         stage('Pre-build') {
             parallel {
                 stage('checkpatch') {


### PR DESCRIPTION
When a new patch is pushed to a PR, cancel any in-progress build/test
jobs.