### PR TITLE
test: Improve test cleanup to not leave stale processes around.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,6 +175,7 @@ pipeline {
                                     trap 'set +e; set -x; ssh -i ci_key jenkins@\$NODE "set -ex; sudo umount \$CART_BASE"' EXIT
                                     ssh -i ci_key jenkins@\$NODE "set -x
                                         set -e
+                                        sudo yum -y install python34-psutil
                                         sudo mkdir -p \$CART_BASE
                                         sudo mount -t nfs \$HOSTNAME:\$PWD \$CART_BASE
                                         cd \$CART_BASE
@@ -212,6 +213,7 @@ pipeline {
                             trap 'set +e; set -x; ssh -i ci_key jenkins@\$NODE "set -ex; sudo umount \$CART_BASE"' EXIT
                             ssh -i ci_key jenkins@\$NODE "set -x
                                 set -e
+                                sudo yum -y install python34-psutil
                                 sudo mkdir -p \$CART_BASE
                                 sudo mount -t nfs \$HOSTNAME:\$PWD \$CART_BASE
                                 cd \$CART_BASE

--- a/test/iof_test_local.py
+++ b/test/iof_test_local.py
@@ -530,7 +530,7 @@ class Testlocal(unittest.TestCase,
                 process = psutil.Process(pid)
             except psutil.NoSuchProcess:
                 continue
-            while (process and process.pid not in known_pids):
+            while process and process.pid not in known_pids:
                 known_pids.add(process.pid)
                 ret.append(process)
                 process = process.parent()

--- a/utils/docker/Dockerfile.centos:7
+++ b/utils/docker/Dockerfile.centos:7
@@ -62,7 +62,7 @@ RUN yum -y install git gcc gcc-c++ make cmake golang libtool scons boost-devel  
                    python34 python34-pylint python34-PyYAML.x86_64 PyYAML        \
                    python2-paramiko python34-paramiko valgrind rsync             \
                    libyaml-devel file ShellCheck yum-plugin-copr python34-nose   \
-                   python34-pip fuse python34-devel
+                   python34-pip fuse python34-devel python34-psutil
 RUN yum -y copr enable jhli/ipmctl
 RUN yum -y copr enable jhli/safeclib
 RUN yum -y install libsafec libipmctl-devel


### PR DESCRIPTION
Use the psutil module to help find and kill processes that were spawned
by the test.

Change-Id: Ic6b5ffeb5066a0deeac672a957933519cd3d5b21
Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>