### PR TITLE
Update FUSE to latest version.

### DIFF
--- a/build.config
+++ b/build.config
@@ -3,7 +3,7 @@ component=iof
 
 [commit_versions]
 CART = 15c7582053487f90ff8ffd15e3282f748100e631
-FUSE = 3e2fcf3a630e575bc420df254525834504dc01b7
+FUSE = a1bff7dbe3ad8950d8cf1b5640aa7a7b2e89211d
 
 [configs]
 cart=utils/build.config

--- a/src/ioc/ioc.h
+++ b/src/ioc/ioc.h
@@ -894,8 +894,9 @@ void ioc_ll_write(fuse_req_t, fuse_ino_t, const char *,	size_t, off_t,
 void ioc_ll_write_buf(fuse_req_t, fuse_ino_t, struct fuse_bufvec *,
 		      off_t, struct fuse_file_info *);
 
-void ioc_ll_ioctl(fuse_req_t, fuse_ino_t, int, void *, struct fuse_file_info *,
-		  unsigned int, const void *, size_t, size_t);
+void ioc_ll_ioctl(fuse_req_t, fuse_ino_t, unsigned int, void *,
+		  struct fuse_file_info *, unsigned int, const void *,
+		  size_t, size_t);
 
 void ioc_ll_setattr(fuse_req_t, fuse_ino_t, struct stat *, int,
 		    struct fuse_file_info *);

--- a/src/ioc/ops/ioctl.c
+++ b/src/ioc/ops/ioctl.c
@@ -68,7 +68,7 @@ handle_gah_ioctl(int cmd, struct iof_file_handle *handle,
 	gah_info->cli_fs_id = fs_handle->proj.cli_fs_id;
 }
 
-void ioc_ll_ioctl(fuse_req_t req, fuse_ino_t ino, int cmd, void *arg,
+void ioc_ll_ioctl(fuse_req_t req, fuse_ino_t ino, unsigned int cmd, void *arg,
 		  struct fuse_file_info *fi, unsigned int flags,
 		  const void *in_buf, size_t in_bufsz, size_t out_bufsz)
 {

--- a/src/ioc/ops/ioctl.c
+++ b/src/ioc/ops/ioctl.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2017-2018 Intel Corporation
+/* Copyright (C) 2017-2019 Intel Corporation
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
There has been a API change to FUSE recently, so update do the
new version.

Signed-off-by: Parallels <ashley.m.pittman@intel.com>