### PR TITLE
CART-566 ft: Update IOF to support new fault injection interface.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,6 +105,7 @@ pipeline {
                         }
                     }
                     steps {
+                        sh "rm iof.conf"
                         sconsBuild clean: "_build.external"
                         stash name: 'CentOS-install', includes: 'install/**'
                         stash name: 'CentOS-build-vars', includes: '.build_vars.*'
@@ -135,6 +136,7 @@ pipeline {
                         }
                     }
                     steps {
+                        sh "rm iof.conf"
                         sconsBuild clean: "_build.external"
                     }
                     post {

--- a/SConstruct
+++ b/SConstruct
@@ -101,7 +101,7 @@ def run_checks(env, prereqs):
     cenv = env.Clone()
     prereqs.require(cenv, 'cart')
     config = Configure(cenv)
-    if config.CheckType('struct d_fault_attr_t', '#include <gurt/fault_inject.h>'):
+    if config.CheckFunc('d_fault_attr_lookup'):
         env.AppendUnique(CPPDEFINES=['GURT_NEW_FI=1'])
     config.Finish()
 

--- a/SConstruct
+++ b/SConstruct
@@ -95,9 +95,9 @@ def run_checks(env, prereqs):
 
     env.AppendIfSupported(CFLAGS=DESIRED_FLAGS)
 
-    # Check for the new fault injection interface.  This is only needed so that IOF
-    # can build against both the old and the new CaRT, and should be removed once
-    # IOF has updated past the change.
+    # Check for the new fault injection interface.  This is only needed so that
+    # IOF can build against both the old and the new CaRT, and should be removed
+    # once IOF has updated past the change.
     cenv = env.Clone()
     prereqs.require(cenv, 'cart')
     config = Configure(cenv)

--- a/SConstruct
+++ b/SConstruct
@@ -79,9 +79,9 @@ def save_build_info(env, prereqs):
 def run_checks(env, prereqs):
     """Run all configure time checks"""
 
-    cenv = env.Clone()
-    cenv.Append(CFLAGS='-Werror')
-    config = Configure(cenv)
+    tenv = env.Clone()
+    tenv.Append(CFLAGS='-Werror')
+    config = Configure(tenv)
 
     cmd = 'setfattr'
     if not config.CheckProg(cmd):
@@ -91,10 +91,19 @@ def run_checks(env, prereqs):
     if config.CheckHeader('stdatomic.h'):
         env.AppendUnique(CPPDEFINES=['HAVE_STDATOMIC=1'])
 
-    prereqs.require(cenv, 'cart')
     config.Finish()
 
     env.AppendIfSupported(CFLAGS=DESIRED_FLAGS)
+
+    # Check for the new fault injection interface.  This is only needed so that IOF
+    # can build against both the old and the new CaRT, and should be removed once
+    # IOF has updated past the change.
+    cenv = env.Clone()
+    prereqs.require(cenv, 'cart')
+    config = Configure(cenv)
+    if config.CheckType('struct d_fault_attr_t', '#include <gurt/fault_inject.h>'):
+        env.AppendUnique(CPPDEFINES=['GURT_NEW_FI=1'])
+    config.Finish()
 
     print('Compiler options: %s %s' % (env.get('CC'),
                                        ' '.join(env.get('CFLAGS'))))


### PR DESCRIPTION
Add a configure check and support code to allow IOF to use both the
new and old FI interfaces.