### PR TITLE
Fix incorrect filename with testing master cart.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,11 +122,6 @@ pipeline {
                                                        excludeFile("_build\\.external\\/.*")]
                             }
                         }
-                        cleanup {
-                            dir('_build.external') {
-                                deleteDir()
-                            }
-                        }
                     }
                 }
                 stage('Build master CentOS 7') {
@@ -156,11 +151,6 @@ pipeline {
                                                        excludeFile('_build\\.external\\/.*')]
                             }
                         }
-                        cleanup {
-                            dir('_build.external') {
-                                deleteDir()
-                            }
-                        }
                     }
                 }
                 stage('Build on Ubuntu 18.04') {
@@ -184,11 +174,6 @@ pipeline {
                                              tools: [ gcc4(), cppCheck() ],
                                              filters: [excludeFile(".*\\/_build\\.external\\/.*"),
                                                        excludeFile("_build\\.external\\/.*")]
-                            }
-                        }
-                        cleanup {
-                            dir('_build.external') {
-                                deleteDir()
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,7 +155,6 @@ pipeline {
                                              filters: [excludeFile('.*\\/_build\\.external\\/.*'),
                                                        excludeFile('_build\\.external\\/.*')]
                             }
-                            archiveArtifacts artifacts: '**/*.log', allowEmptyArchive: true
                         }
                         cleanup {
                             dir('_build.external') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,8 +122,10 @@ pipeline {
                                                        excludeFile("_build\\.external\\/.*")]
                             }
                         }
-                        success {
-                            sh "rm -rf _build.external"
+                        cleanup {
+                            dir('_build.external') {
+                                deleteDir()
+                            }
                         }
                     }
                 }
@@ -155,8 +157,10 @@ pipeline {
                             }
                             archiveArtifacts artifacts: '**/*.log', allowEmptyArchive: true
                         }
-                        success {
-                            sh "rm -rf _build.external"
+                        cleanup {
+                            dir('_build.external') {
+                                deleteDir()
+                            }
                         }
                     }
                 }
@@ -183,8 +187,10 @@ pipeline {
                                                        excludeFile("_build\\.external\\/.*")]
                             }
                         }
-                        success {
-                            sh "rm -rf _build.external"
+                        cleanup {
+                            dir('_build.external') {
+                                deleteDir()
+                            }
                         }
                     }
                 }
@@ -267,7 +273,7 @@ pipeline {
                                         pip3.4 install --user tabulate
                                         export TR_USE_VALGRIND=none
                                         export IOF_TESTLOG=test/output-master
-                                        nosetests-3.4 --xunit-testsuite-name=centos --xunit-file=nosetests-centos.xml --exe --with-xunit"
+                                        nosetests-3.4 --xunit-testsuite-name=master --xunit-file=nosetests-master.xml --exe --with-xunit"
                                     exit 0
                                     """,
                                 junit_files: 'nosetests-master.xml'

--- a/check_modules.sh
+++ b/check_modules.sh
@@ -38,7 +38,7 @@
 
 
 FLIST="-s SConstruct -s src/SConscript -s src/utest/SConscript "
-FLIST+="-s src/test/SConscript"
+FLIST+="-s src/test/SConscript -s test/SConscript"
 
 FILE=`ls -1 test/*.py`
 for FNAME in $FILE

--- a/test/SConscript
+++ b/test/SConscript
@@ -48,4 +48,3 @@ def scons():
 
 if __name__ == 'SCons.Script':
     scons()
-


### PR DESCRIPTION
Use deleteDir() rather than sh "rm -rf...
Add a SConscript to the check_modules script, and fix errors.

Signed-off-by: Ashley Pittman <ashley.m.pittman@intel.com>