### PR TITLE
Retry context_destroy() on failure.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,7 +107,7 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild(clean: '_build.external iof.conf')
+                        sconsBuild(clean: '_build.external')
                         stash name: 'CentOS-install', includes: 'install/**'
                         stash name: 'CentOS-build-vars', includes: '.build_vars.*'
                     }
@@ -135,7 +135,7 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild(clean: '_build.external iof.conf',
+                        sconsBuild(clean: '_build.external',
                                    scons_args: '--build-config=utils/build-master.config')
                         stash name: 'CentOS-master-install', includes: 'install/**'
                         stash name: 'CentOS-master-build-vars', includes: ".build_vars.*"
@@ -163,7 +163,7 @@ pipeline {
                         }
                     }
                     steps {
-                        sconsBuild(clean: '_build.external iof.conf')
+                        sconsBuild(clean: '_build.external')
                     }
                     post {
                         always {

--- a/src/ionss/ionss.c
+++ b/src/ionss/ionss.c
@@ -3101,7 +3101,7 @@ shutdown_no_proj:
 
 	ret = crt_context_destroy(base.crt_ctx, false);
 	if (ret != -DER_SUCCESS) {
-		IOF_LOG_ERROR("Could not destroy context, trying force %d",
+		IOF_LOG_INFO("Could not destroy context, trying force %d",
 			      ret);
 		if (ret == -DER_TIMEDOUT) {
 			ret = crt_context_destroy(base.crt_ctx, true);

--- a/src/ionss/ionss.c
+++ b/src/ionss/ionss.c
@@ -3108,6 +3108,7 @@ shutdown_no_proj:
 			if (ret != -DER_SUCCESS) {
 				IOF_LOG_ERROR("Could not destroy context, giving up %d",
 					      ret);
+			}
 		}
 		if (ret != -DER_SUCCESS) {
 			if (exit_rc == -DER_SUCCESS) {

--- a/src/ionss/ionss.c
+++ b/src/ionss/ionss.c
@@ -3099,11 +3099,20 @@ shutdown_no_proj:
 
 	D_RWLOCK_DESTROY(&base.gah_rwlock);
 
-	ret = crt_context_destroy(base.crt_ctx, 0);
-	if (ret) {
-		IOF_LOG_ERROR("Could not destroy context");
-		if (exit_rc == -DER_SUCCESS) {
-			exit_rc = ret;
+	ret = crt_context_destroy(base.crt_ctx, false);
+	if (ret != -DER_SUCCESS) {
+		IOF_LOG_ERROR("Could not destroy context, trying force %d",
+			      ret);
+		if (ret == -DER_TIMEDOUT) {
+			ret = crt_context_destroy(base.crt_ctx, true);
+			if (ret != -DER_SUCCESS) {
+				IOF_LOG_ERROR("Could not destroy context, giving up %d",
+					      ret);
+		}
+		if (ret != -DER_SUCCESS) {
+			if (exit_rc == -DER_SUCCESS) {
+				exit_rc = ret;
+			}
 		}
 	}
 

--- a/utils/build.config
+++ b/utils/build.config
@@ -2,7 +2,7 @@
 component=iof
 
 [commit_versions]
-CART = 15c7582053487f90ff8ffd15e3282f748100e631
+CART = master
 FUSE = a1bff7dbe3ad8950d8cf1b5640aa7a7b2e89211d
 
 [configs]

--- a/utils/build.config
+++ b/utils/build.config
@@ -2,7 +2,7 @@
 component=iof
 
 [commit_versions]
-CART = master
+CART = 15c7582053487f90ff8ffd15e3282f748100e631
 FUSE = a1bff7dbe3ad8950d8cf1b5640aa7a7b2e89211d
 
 [configs]


### PR DESCRIPTION
If there is timeout calling shutdown destroy return, passing the force
option.  This should allow any Swim RPCs to be completed, and shutdown
to complete normally.